### PR TITLE
Fix yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-74753896-abd8-48b9-ab9c-64331651066a-docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
 
   redis:
     image: redis:alpine
+    security_opt:
+      - no-new-privileges:true
 
   sqli:
     build:


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-74753896-abd8-48b9-ab9c-64331651066a-docker-compose.yml.