### PR TITLE
Fix yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-39b0f320-f463-49c8-9d04-a429a2332713-docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
 
   redis:
     image: redis:alpine
+    volumes:
+      - type: tmpfs
+        target: /data
+        tmpfs:
+          size: 100M
 
   sqli:
     build:


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-39b0f320-f463-49c8-9d04-a429a2332713-docker-compose.yml.